### PR TITLE
Test 'nng' package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,37 +37,37 @@ matrix:
     - os: linux
       env: >
         TOOLCHAIN=clang-cxx17
-        PROJECT_DIR=examples/foo
+        PROJECT_DIR=examples/nng
 
     - os: linux
       env: >
         TOOLCHAIN=gcc-7-cxx17
-        PROJECT_DIR=examples/foo
+        PROJECT_DIR=examples/nng
 
     - os: linux
       env: >
         TOOLCHAIN=android-ndk-r17-api-24-arm64-v8a-clang-libcxx14
-        PROJECT_DIR=examples/foo
+        PROJECT_DIR=examples/nng
 
     - os: linux
       env: >
         TOOLCHAIN=analyze-cxx17
-        PROJECT_DIR=examples/foo
+        PROJECT_DIR=examples/nng
 
     - os: linux
       env: >
         TOOLCHAIN=sanitize-address-cxx17
-        PROJECT_DIR=examples/foo
+        PROJECT_DIR=examples/nng
 
     - os: linux
       env: >
         TOOLCHAIN=sanitize-leak-cxx17
-        PROJECT_DIR=examples/foo
+        PROJECT_DIR=examples/nng
 
     - os: linux
       env: >
         TOOLCHAIN=sanitize-thread-cxx17
-        PROJECT_DIR=examples/foo
+        PROJECT_DIR=examples/nng
 
     # }
 
@@ -77,19 +77,19 @@ matrix:
       osx_image: xcode9.4
       env: >
         TOOLCHAIN=osx-10-13-make-cxx14
-        PROJECT_DIR=examples/foo
+        PROJECT_DIR=examples/nng
 
     - os: osx
       osx_image: xcode9.4
       env: >
         TOOLCHAIN=osx-10-13-cxx14
-        PROJECT_DIR=examples/foo
+        PROJECT_DIR=examples/nng
 
     - os: osx
       osx_image: xcode9.4
       env: >
         TOOLCHAIN=ios-nocodesign-11-4-dep-9-3
-        PROJECT_DIR=examples/foo
+        PROJECT_DIR=examples/nng
 
     # }
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,27 +9,27 @@ environment:
   matrix:
 
     - TOOLCHAIN: "ninja-vs-15-2017-win64-cxx17"
-      PROJECT_DIR: examples\foo
+      PROJECT_DIR: examples\nng
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
 
     - TOOLCHAIN: "nmake-vs-15-2017-win64-cxx17"
-      PROJECT_DIR: examples\foo
+      PROJECT_DIR: examples\nng
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
 
     - TOOLCHAIN: "vs-15-2017-win64-cxx17"
-      PROJECT_DIR: examples\foo
+      PROJECT_DIR: examples\nng
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
 
     - TOOLCHAIN: "vs-14-2015-sdk-8-1"
-      PROJECT_DIR: examples\foo
+      PROJECT_DIR: examples\nng
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
     - TOOLCHAIN: "mingw-cxx17"
-      PROJECT_DIR: examples\foo
+      PROJECT_DIR: examples\nng
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
     - TOOLCHAIN: "msys-cxx17"
-      PROJECT_DIR: examples\foo
+      PROJECT_DIR: examples\nng
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
 install:


### PR DESCRIPTION
* I've followed [this guide](https://docs.hunter.sh/en/latest/creating-new/create/cmake.html)
  step by step carefully. **[Yes]**

* I've tested this package remotely and have excluded all broken builds.
  Here is the links to the Travis/AppVeyor with status "All passed": **[No, still running]**
  
  * https://ci.appveyor.com/project/tnixeu/hunter-old/builds/28362002
  * https://travis-ci.org/tnixeu/hunter_old/builds/602497173

Which of those is now correct?

If I do this pull request here I get:
* I have submitted CI configs to https://github.com/ingenue/hunter targeting `pkg.template` branch,
  see this merged pull request https://github.com/ingenue/hunter/pull/<number>

If I start a pull request for the hunter changes on the cpp-pm/hunter, then I get this.
* I have submitted CI configs to https://github.com/cpp-pm/hunter-testing targeting `pkg.template` branch,
  see this merged pull request https://github.com/cpp-pm/hunter-testing/pull/<number>

are those things even the correct template here?