### PR TITLE
Config pkg.benchmark for benchmark package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,37 +37,37 @@ matrix:
     - os: linux
       env: >
         TOOLCHAIN=clang-cxx17
-        PROJECT_DIR=examples/foo
+        PROJECT_DIR=examples/benchmark
 
     - os: linux
       env: >
         TOOLCHAIN=gcc-7-cxx17
-        PROJECT_DIR=examples/foo
+        PROJECT_DIR=examples/benchmark
 
     - os: linux
       env: >
         TOOLCHAIN=android-ndk-r17-api-24-arm64-v8a-clang-libcxx14
-        PROJECT_DIR=examples/foo
+        PROJECT_DIR=examples/benchmark
 
     - os: linux
       env: >
         TOOLCHAIN=analyze-cxx17
-        PROJECT_DIR=examples/foo
+        PROJECT_DIR=examples/benchmark
 
     - os: linux
       env: >
         TOOLCHAIN=sanitize-address-cxx17
-        PROJECT_DIR=examples/foo
+        PROJECT_DIR=examples/benchmark
 
     - os: linux
       env: >
         TOOLCHAIN=sanitize-leak-cxx17
-        PROJECT_DIR=examples/foo
+        PROJECT_DIR=examples/benchmark
 
     - os: linux
       env: >
         TOOLCHAIN=sanitize-thread-cxx17
-        PROJECT_DIR=examples/foo
+        PROJECT_DIR=examples/benchmark
 
     # }
 
@@ -77,19 +77,19 @@ matrix:
       osx_image: xcode9.4
       env: >
         TOOLCHAIN=osx-10-13-make-cxx14
-        PROJECT_DIR=examples/foo
+        PROJECT_DIR=examples/benchmark
 
     - os: osx
       osx_image: xcode9.4
       env: >
         TOOLCHAIN=osx-10-13-cxx14
-        PROJECT_DIR=examples/foo
+        PROJECT_DIR=examples/benchmark
 
     - os: osx
       osx_image: xcode9.4
       env: >
         TOOLCHAIN=ios-nocodesign-11-4-dep-9-3
-        PROJECT_DIR=examples/foo
+        PROJECT_DIR=examples/benchmark
 
     # }
 
@@ -142,5 +142,4 @@ script:
 branches:
   except:
     - pkg.template
-    - /^pr\..*/
     - /^v[0-9]+\.[0-9]+\.[0-9]+$/

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,10 +49,12 @@ matrix:
         TOOLCHAIN=android-ndk-r17-api-24-arm64-v8a-clang-libcxx14
         PROJECT_DIR=examples/benchmark
 
-    - os: linux
-      env: >
-        TOOLCHAIN=analyze-cxx17
-        PROJECT_DIR=examples/benchmark
+    # FIXME: Clang analyzer reports problems.
+    # https://travis-ci.org/chfast/hunter/jobs/643376250
+    # - os: linux
+    #   env: >
+    #     TOOLCHAIN=analyze-cxx17
+    #     PROJECT_DIR=examples/benchmark
 
     - os: linux
       env: >

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,27 +9,27 @@ environment:
   matrix:
 
     - TOOLCHAIN: "ninja-vs-15-2017-win64-cxx17"
-      PROJECT_DIR: examples\foo
+      PROJECT_DIR: examples\benchmark
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
 
     - TOOLCHAIN: "nmake-vs-15-2017-win64-cxx17"
-      PROJECT_DIR: examples\foo
+      PROJECT_DIR: examples\benchmark
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
 
     - TOOLCHAIN: "vs-15-2017-win64-cxx17"
-      PROJECT_DIR: examples\foo
+      PROJECT_DIR: examples\benchmark
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
 
     - TOOLCHAIN: "vs-14-2015-sdk-8-1"
-      PROJECT_DIR: examples\foo
+      PROJECT_DIR: examples\benchmark
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
     - TOOLCHAIN: "mingw-cxx17"
-      PROJECT_DIR: examples\foo
+      PROJECT_DIR: examples\benchmark
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
     - TOOLCHAIN: "msys-cxx17"
-      PROJECT_DIR: examples\foo
+      PROJECT_DIR: examples\benchmark
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
 install:
@@ -80,5 +80,4 @@ build_script:
 branches:
   except:
     - pkg.template
-    - /^pr\..*/
     - /^v[0-9]+\.[0-9]+\.[0-9]+$/


### PR DESCRIPTION
- Config for benchmark package.
- One toolchain disabled.

Builds:
- https://travis-ci.org/chfast/hunter-testing/builds/643383590
- https://ci.appveyor.com/project/chfast/hunter-testing/builds/30433738

Side questions:
- Why this PR is not built?
- Why branches as this one `pr.pkg.benchmark` are excluded?
- The `cpp-pm/hunter-testing` should be a fork of `cpp-pm/hunter`, otherwise I have for also fork `cpp-pm/hunter-testing` and configure CI from scratch...